### PR TITLE
CodeGenerator: block linearization via reverse post-order

### DIFF
--- a/src/main/scala/mjis/CodeGenerator.scala
+++ b/src/main/scala/mjis/CodeGenerator.scala
@@ -69,9 +69,7 @@ class CodeGenerator(a: Unit) extends Phase[AsmProgram] {
       basicBlocks.values.foreach(generateInstructionsForPhi)
 
       function.epilogue.controlFlowInstructions += Ret()
-      function.basicBlocks = (Seq(basicBlocks(g.getStartBlock)) ++
-        basicBlocks.keys.filter(b => b != g.getStartBlock && b != g.getEndBlock).map(basicBlocks) ++
-        Seq(basicBlocks(g.getEndBlock))).toList
+      function.basicBlocks = NodeCollector.getBlocksInReverseBackEdgesPostOrder(g).map(basicBlocks).toList
       function
     }
 

--- a/src/main/scala/mjis/opt/NodeCollector.scala
+++ b/src/main/scala/mjis/opt/NodeCollector.scala
@@ -1,7 +1,8 @@
 package mjis.opt
 
-import firm.BlockWalker
 import firm.nodes._
+import firm.{BlockWalker, Graph}
+import FirmExtensions._
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -22,5 +23,22 @@ object NodeCollector {
       override def visitBlock(block: Block): Unit = blocks += block
     })
     blocks
+  }
+
+  def getBlocksInReverseBackEdgesPostOrder(g: Graph): Seq[Block] = {
+    val postOrder = ArrayBuffer[Block]()
+    val edges = g.getBlockBackEdges
+
+    def visit(block: Block): Unit = {
+      if (!block.blockVisited) {
+        block.markBlockVisited()
+        edges(block).foreach(visit)
+        postOrder += block
+      }
+    }
+
+    g.incBlockVisited()
+    visit(g.getStartBlock)
+    postOrder.reverse
   }
 }

--- a/src/test/scala/mjis/CodeGeneratorTest.scala
+++ b/src/test/scala/mjis/CodeGeneratorTest.scala
@@ -261,13 +261,13 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
         |  movl %esi, %REG1{4}  # argI
         |.L0:
         |  cmpb $1, %REG0{1}
-        |  je .L2
-        |  jmp .L1
+        |  je .L1
+        |  jmp .L2
         |.L1:
-        |  movl %REG1{4}, %REG2{4}
+        |  movl $0, %REG2{4}
         |  jmp .L3
         |.L2:
-        |  movl $0, %REG2{4}
+        |  movl %REG1{4}, %REG2{4}
         |  jmp .L3
         |.L3:
         |  movl %REG2{4}, %eax
@@ -302,16 +302,16 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
           |.L0:
           |  movl $42, %REG1{4}         # y => REG1
           |  movl %REG0{4}, %REG2{4}    # x => REG2
-          |  jmp .L2
+          |  jmp .L1
           |.L1:
+          |  cmpl $5, %REG2{4}
+          |  jl .L2
+          |  jmp .L3
+          |.L2:
           |  movl %REG1{4}, %REG3{4}    # tmp = y
           |  movl %REG2{4}, %REG1{4}    # y = x
           |  movl %REG3{4}, %REG2{4}    # x = tmp
-          |  jmp .L2
-          |.L2:
-          |  cmpl $5, %REG2{4}
-          |  jl .L1
-          |  jmp .L3
+          |  jmp .L1
           |.L3:
           |  movl %REG1{4}, %eax
           |  jmp .L4

--- a/src/test/scala/mjis/opt/FirmExtensionsTest.scala
+++ b/src/test/scala/mjis/opt/FirmExtensionsTest.scala
@@ -2,7 +2,6 @@ package mjis.opt
 
 import firm._
 import firm.nodes._
-import mjis.util.FirmDumpHelper
 import org.scalatest._
 import mjis.opt.FirmExtensions._
 import mjis.opt.FirmExtractors._


### PR DESCRIPTION
Something like -10% time for fannkuch on my machine