### PR TITLE
Don't visit Bad nodes during getBlockBackEdges.

### DIFF
--- a/src/main/scala/mjis/opt/FirmExtensions.scala
+++ b/src/main/scala/mjis/opt/FirmExtensions.scala
@@ -31,7 +31,7 @@ object FirmExtensions {
       val m = mutable.Map[Block, Set[Block]]().withPersistentDefault(_ => Set.empty)
       g.walkBlocks(new BlockWalker {
         override def visitBlock(block: Block): Unit = {
-          for (pred <- block.getPreds)
+          for (pred <- block.getPreds.filter(!_.isInstanceOf[Bad]))
             m(pred.getBlock.asInstanceOf[Block]) += block
         }
       })


### PR DESCRIPTION
This prevents code generation for unreachable blocks.