### PR TITLE
Support for AR operands and varying operand sizes in PhiCodeGenerator

### DIFF
--- a/src/main/scala/mjis/CodeGenerator.scala
+++ b/src/main/scala/mjis/CodeGenerator.scala
@@ -47,8 +47,6 @@ class CodeGenerator(a: Unit) extends Phase[AsmProgram] {
   })
 
   class MethodCodeGenerator(g: Graph) {
-    def appendComment(s: String): Instruction => Instruction = { instr => instr.comment += s; instr }
-
     val basicBlocks = mutable.ListMap[Block, AsmBasicBlock]().
       withPersistentDefault(b => new AsmBasicBlock(if (b == null) -1 else b.getNr))
     val function = new AsmFunction(g.getEntity.getLdName)
@@ -93,8 +91,8 @@ class CodeGenerator(a: Unit) extends Phase[AsmProgram] {
 
       for (n <- NodeCollector.fromWalk(g.walkTopological)) {
         val basicBlock = basicBlocks(n.block)
-        basicBlock.instructions ++= instructions.getOrElse(n, Seq()) map appendComment(" - " + n.toString)
-        basicBlock.controlFlowInstructions ++= createControlFlow(n, nextBlock.get(basicBlock)) map appendComment(" - " + n.toString)
+        basicBlock.instructions ++= instructions.getOrElse(n, Seq()) map(_.withComment(s" - $n"))
+        basicBlock.controlFlowInstructions ++= createControlFlow(n, nextBlock.get(basicBlock)) map(_.withComment(s" - $n"))
       }
       if (!backEdgesWereEnabled) BackEdges.disable(g)
 

--- a/src/main/scala/mjis/PhiCodeGenerator.scala
+++ b/src/main/scala/mjis/PhiCodeGenerator.scala
@@ -4,83 +4,108 @@ import mjis.asm._
 
 import scala.collection.mutable
 
-/** Creates Mov instructions for the contents of `phi` with parallel move semantics. */
-class PhiCodeGenerator(phi: Map[RegisterOperand, Operand]) {
+/** Creates Mov instructions for a map of parallel moves. */
+class PhiCodeGenerator(inputPhi: Map[Operand, Operand], cycleTempRegNr: Int, memMoveTempRegNr: Int) {
   // A phi permutation interpreted as a graph looks as follows: Each node has indegree <= 1
   // (because each register is written to at most once) and arbitrary outdegree.
   // Each of the connected subgraphs is thus either acyclic (and therefore a tree) or contains
   // exactly one cycle (else there would be a node with indegree >= 2).
   // Each of the nodes in the cycle can optionally be the root of a tree.
 
+  val originalDestOp = mutable.Map[Operand, Operand]()
+
+  val unifiedPhi = inputPhi.map { case (dest, src) =>
+    originalDestOp(unifyOp(dest)) = dest
+    unifyOp(dest) -> unifyOp(src)
+  }.toMap
+
   // Inverse of the Phi map: source operand -> list of registers its value is written to
-  private val invertedPhi: Map[Operand, Iterable[RegisterOperand]] =
-    phi.groupBy(_._2).mapValues(_.map(_._1)).withDefaultValue(Seq())
+  private val invertedUnifiedPhi: Map[Operand, Iterable[Operand]] =
+    unifiedPhi.groupBy(_._2).mapValues(_.map(_._1)).withDefaultValue(Seq())
 
   // Cycles
-  private val cycles = mutable.ArrayBuffer[List[RegisterOperand]]()
+  private val cycles = mutable.ArrayBuffer[List[Operand]]()
 
   // Roots of standalone trees
   private val roots = mutable.ArrayBuffer[Operand]()
 
+  /* Returns a unified version (all sizeBytes stripped out) of an operand.
+   * Only these unified operands are used in the dependency graph construction
+   * so that permutations like "$0 -> eax, rax -> rbx" are correctly ordered. */
+  private def unifyOp: Operand => Operand = {
+    case r: RegisterOperand => r.copy(sizeBytes = 0)
+    case a: ActivationRecordOperand => a.copy(sizeBytes = 0)
+    case op => op
+  }
+
   private def buildCyclesAndRoots() = {
     @annotation.tailrec
-    def buildCyclesAndRootsRec(reg: RegisterOperand, stack: List[RegisterOperand],
-        visited: mutable.Set[RegisterOperand]): Unit = {
-      if (visited(reg)) {
-        if (stack.nonEmpty && stack.contains(reg)) {
+    def buildCyclesAndRootsRec(current: Operand, stack: List[Operand],
+        visited: mutable.Set[Operand]): Unit = {
+      if (visited(current)) {
+        if (stack.nonEmpty && stack.contains(current)) {
           // found cycle
-          cycles += reg :: stack.takeWhile(_ != reg)
+          cycles += current :: stack.takeWhile(_ != current)
         }
       } else {
-        visited += reg
-        phi.get(reg) match {
+        visited += current
+        unifiedPhi.get(current) match {
           case None =>
             // no predecessor -> root of a tree
-            roots += reg
-          case Some(r : RegisterOperand) =>
-            buildCyclesAndRootsRec(r, reg :: stack, visited)
-          case Some(op) =>
-            // non-register operand -> has no predecessor -> root of a tree
-            if (!roots.contains(op))
-              roots += op
+            if (!roots.contains(current))
+              roots += current
+          case Some(r) =>
+            buildCyclesAndRootsRec(r, current :: stack, visited)
         }
       }
     }
 
-    val visited = mutable.Set[RegisterOperand]()
-    phi.keys.foreach(buildCyclesAndRootsRec(_, Nil, visited))
+    val visited = mutable.Set[Operand]()
+    unifiedPhi.keys.foreach(buildCyclesAndRootsRec(_, Nil, visited))
+  }
+
+  private def mov(srcOp: Operand, destOp: Operand) = (srcOp, destOp) match {
+    case (_: ActivationRecordOperand, _: ActivationRecordOperand) => Seq(
+      Mov(srcOp, RegisterOperand(memMoveTempRegNr, srcOp.sizeBytes)),
+      Mov(RegisterOperand(memMoveTempRegNr, destOp.sizeBytes), destOp)
+    )
+    case _ => Seq(Mov(srcOp, destOp))
   }
 
   /** Writes the acyclic register permutation (= tree) starting at `rootOp`, skipping the successor
     * `cycleSuccessor` of `rootOp`. */
-  private def getInstructionsForTree(rootOp: Operand, cycleSuccessor: RegisterOperand): Seq[Instruction] = {
-    val workList = mutable.Queue[RegisterOperand]()
-    workList ++= invertedPhi(rootOp).filter(_ != cycleSuccessor)
+  private def getInstructionsForTree(rootOp: Operand, cycleSuccessor: Operand): Seq[Instruction] = {
+    val workList = mutable.Queue[Operand]()
+    workList ++= invertedUnifiedPhi(rootOp).filter(_ != cycleSuccessor)
 
-    var ordered = List[RegisterOperand]()
+    var ordered = List[Operand]()
     while (workList.nonEmpty) {
       val op = workList.dequeue()
       ordered = op :: ordered
-      workList ++= invertedPhi(op)
+      workList ++= invertedUnifiedPhi(op)
     }
 
-    ordered.map { destOp =>
-      val srcOp = phi(destOp)
-      Mov(srcOp, destOp).withComment(s" - acyclic permutation starting at $rootOp")
-    }
+    ordered.flatMap { destOpUnified =>
+      val destOp = originalDestOp(destOpUnified)
+      val srcOp = inputPhi(destOp)
+      mov(srcOp, destOp)
+    } map(_.withComment(s" - acyclic permutation starting at $rootOp"))
   }
 
   /** Writes the given cyclic permutation using a temporary register. */
-  private def getInstructionsForCycle(cycle: List[RegisterOperand]): Seq[Instruction] = {
+  private def getInstructionsForCycle(cycle: List[Operand]): Seq[Instruction] = {
     assert(cycle.length >= 2)
     val comment = " - cyclic permutation " + cycle.mkString(" -> ")
 
-    val destRegOp = cycle.last
-    val tempRegister = RegisterOperand(0, destRegOp.sizeBytes)
+    val tempRegister = RegisterOperand(cycleTempRegNr, originalDestOp(cycle.head).sizeBytes)
 
-    (tempRegister :: cycle).sliding(2).map { case Seq(destOp, srcOp) =>
-      Mov(srcOp, destOp).withComment(comment)
-    }.toSeq ++ Seq(Mov(tempRegister, destRegOp).withComment(comment))
+    (Mov(inputPhi(originalDestOp(cycle.head)), tempRegister) +:
+    cycle.tail.flatMap { destOpUnified =>
+      val destOp = originalDestOp(destOpUnified)
+      val srcOp = inputPhi(destOp)
+      mov(srcOp, destOp)
+    }.toSeq :+
+    Mov(tempRegister, originalDestOp(cycle.head))) map(_.withComment(comment))
   }
 
   def getInstructions(): Seq[Instruction] = {

--- a/src/main/scala/mjis/RegisterAllocator.scala
+++ b/src/main/scala/mjis/RegisterAllocator.scala
@@ -93,10 +93,10 @@ class FunctionRegisterAllocator(function: AsmFunction) {
   def allocateRegs() = {
     // Insert Mov instructions for Phi functions
     for ((pred, succ) <- function.controlFlowEdges) {
-      val parallelMoves = succ.phis.map { phi =>
+      val parallelMoves: Map[Operand, Operand] = succ.phis.map { phi =>
         phi.dest -> phi.srcs(succ.predecessors.indexOf(Some(pred)))
       }.toMap
-      val phiInstrs = new PhiCodeGenerator(parallelMoves).getInstructions()
+      val phiInstrs = new PhiCodeGenerator(parallelMoves, 0, 0).getInstructions()
 
       if (succ.predecessors.flatten.length == 1) {
         succ.instructions.insertAll(0, phiInstrs)

--- a/src/main/scala/mjis/asm/Instruction.scala
+++ b/src/main/scala/mjis/asm/Instruction.scala
@@ -97,7 +97,7 @@ object OperandSpec {
 abstract class Instruction(private val operandsWithSpec: (Operand, OperandSpec)*) {
   var comment = ""
   def opcode: String = this.getClass.getSimpleName.toLowerCase.stripSuffix("$")
-  def withComment(comment: String) = { this.comment = comment; this }
+  def withComment(comment: String) = { this.comment += comment; this }
   var stackPointerDisplacement: Int = 0
   def withStackPointerDisplacement(displacement: Int): Instruction = {
     this.stackPointerDisplacement = displacement

--- a/src/test/scala/mjis/PhiCodeGeneratorTest.scala
+++ b/src/test/scala/mjis/PhiCodeGeneratorTest.scala
@@ -1,25 +1,42 @@
 package mjis
 
-import mjis.asm.{Mov, RegisterOperand}
+import mjis.asm._
 import org.scalatest._
 
 class PhiCodeGeneratorTest extends FlatSpec with Matchers {
 
   "The Phi code generator" should "circumvent the Swap problem" in {
-    val phiMap = Map(
+    val phiMap: Map[Operand, Operand] = Map(
       RegisterOperand(10, 4) -> RegisterOperand(20, 4),
       RegisterOperand(20, 4) -> RegisterOperand(10, 4)
     )
 
-    new PhiCodeGenerator(phiMap).getInstructions() should contain inOrderOnly (
-      Mov(RegisterOperand(20, 4), RegisterOperand(0, 4)),
-      Mov(RegisterOperand(10, 4), RegisterOperand(20, 4)),
-      Mov(RegisterOperand(0, 4), RegisterOperand(10, 4))
+    new PhiCodeGenerator(phiMap, 100, 101).getInstructions() should contain inOrderOnly (
+      Mov(RegisterOperand(10, 4), RegisterOperand(100, 4)),
+      Mov(RegisterOperand(20, 4), RegisterOperand(10, 4)),
+      Mov(RegisterOperand(100, 4), RegisterOperand(20, 4))
+    )
+  }
+
+  it should "generate instructions for a longer cycle" in {
+    val phiMap: Map[Operand, Operand] = Map(
+      RegisterOperand(10, 4) -> RegisterOperand(20, 4),
+      RegisterOperand(20, 4) -> RegisterOperand(30, 4),
+      RegisterOperand(30, 4) -> RegisterOperand(40, 4),
+      RegisterOperand(40, 4) -> RegisterOperand(10, 4)
+    )
+
+    new PhiCodeGenerator(phiMap, 100, 101).getInstructions() should contain inOrderOnly (
+      Mov(RegisterOperand(30, 4), RegisterOperand(100, 4)),
+      Mov(RegisterOperand(40, 4), RegisterOperand(30, 4)),
+      Mov(RegisterOperand(10, 4), RegisterOperand(40, 4)),
+      Mov(RegisterOperand(20, 4), RegisterOperand(10, 4)),
+      Mov(RegisterOperand(100, 4), RegisterOperand(20, 4))
     )
   }
 
   it should "generate code for Phis with multiple outputs" in {
-    val phiMap = Map(
+    val phiMap: Map[Operand, Operand] = Map(
       RegisterOperand(50, 4) -> RegisterOperand(30, 4),
       RegisterOperand(40, 4) -> RegisterOperand(30, 4),
       RegisterOperand(30, 4) -> RegisterOperand(10, 4),
@@ -27,13 +44,39 @@ class PhiCodeGeneratorTest extends FlatSpec with Matchers {
       RegisterOperand(20, 4) -> RegisterOperand(10, 4)
     )
 
-    new PhiCodeGenerator(phiMap).getInstructions() should contain inOrderOnly (
+    new PhiCodeGenerator(phiMap, 100, 101).getInstructions() should contain inOrderOnly (
       Mov(RegisterOperand(30, 4), RegisterOperand(40, 4)),
       Mov(RegisterOperand(30, 4), RegisterOperand(50, 4)),
       Mov(RegisterOperand(10, 4), RegisterOperand(30, 4)),
-      Mov(RegisterOperand(20, 4), RegisterOperand(0, 4)),
-      Mov(RegisterOperand(10, 4), RegisterOperand(20, 4)),
-      Mov(RegisterOperand(0, 4), RegisterOperand(10, 4))
+      Mov(RegisterOperand(10, 4), RegisterOperand(100, 4)),
+      Mov(RegisterOperand(20, 4), RegisterOperand(10, 4)),
+      Mov(RegisterOperand(100, 4), RegisterOperand(20, 4))
+    )
+  }
+
+  it should "generate moves for ActivationRecordOperands" in {
+    val phiMap: Map[Operand, Operand] = Map(
+      ActivationRecordOperand(0, 4) -> RegisterOperand(20, 4),
+      ActivationRecordOperand(1, 4) -> ActivationRecordOperand(0, 4)
+    )
+
+    new PhiCodeGenerator(phiMap, 100, 101).getInstructions() should contain inOrderOnly (
+      Mov(ActivationRecordOperand(0, 4), RegisterOperand(101, 4)),
+      Mov(RegisterOperand(101, 4), ActivationRecordOperand(1, 4)),
+      Mov(RegisterOperand(20, 4), ActivationRecordOperand(0, 4))
+    )
+  }
+
+  it should "order operands of different size" in {
+    val phiMap: Map[Operand, Operand] = Map(
+      RegisterOperand(10, 8) -> RegisterOperand(20, 8),
+      RegisterOperand(20, 4) -> RegisterOperand(10, 4)
+    )
+
+    new PhiCodeGenerator(phiMap, 100, 101).getInstructions() should contain inOrderOnly (
+      Mov(RegisterOperand(10, 4), RegisterOperand(100, 4)),
+      Mov(RegisterOperand(20, 8), RegisterOperand(10, 8)),
+      Mov(RegisterOperand(100, 4), RegisterOperand(20, 4))
     )
   }
 


### PR DESCRIPTION
We'll need the PhiCodeGenerator to generate more parallel/interdependent moves (spill moves and moves between split intervals) in the upcoming register allocator.