### PR TITLE
Find loops via SCCs

### DIFF
--- a/src/main/scala/mjis/Optimizer.scala
+++ b/src/main/scala/mjis/Optimizer.scala
@@ -3,7 +3,7 @@ package mjis
 import firm._
 import java.io.BufferedWriter
 import firm.nodes.Bad
-import mjis.util.FirmDumpHelper
+import mjis.util.{Digraph, FirmDumpHelper}
 import mjis.opt._
 import mjis.opt.FirmExtensions._
 import scala.collection.JavaConversions._
@@ -17,8 +17,7 @@ class Optimizer(input: Unit) extends Phase[Unit] {
   }
 
   private def removeCriticalEdges(g: Graph): Unit = {
-    BackEdges.enable(g)
-    val backEdges = g.getBlockBackEdges
+    val backEdges = Digraph.transpose(g.getBlockEdges)
     for (block <- NodeCollector.fromBlockWalk(g.walkBlocks))
       if (block.getPreds.count(!_.isInstanceOf[Bad]) > 1)
         for ((pred, idx) <- block.getPreds.zipWithIndex if !pred.isInstanceOf[Bad])
@@ -26,7 +25,6 @@ class Optimizer(input: Unit) extends Phase[Unit] {
             val newBlock = g.newBlock(Array(pred))
             block.setPred(idx, g.newJmp(newBlock))
           }
-    BackEdges.disable(g)
   }
 
   val highLevelOptimizations = List(LoopStrengthReduction, RedundantLoadElimination)

--- a/src/main/scala/mjis/opt/DataFlowAnalysis.scala
+++ b/src/main/scala/mjis/opt/DataFlowAnalysis.scala
@@ -2,6 +2,7 @@ package mjis.opt
 
 import firm._
 import firm.nodes._
+import mjis.util.Digraph
 import scala.collection.mutable
 import scala.collection.JavaConversions._
 import mjis.opt.FirmExtensions._
@@ -29,7 +30,7 @@ object DataFlowAnalysis {
     val m = mutable.Map[Block, A]().withDefaultValue(bot)
 
     val worklist = NodeCollector.fromBlockWalk(g.walkBlocks).to[mutable.Queue]
-    val backEdges = g.getBlockBackEdges
+    val backEdges = Digraph.transpose(g.getBlockEdges)
 
     while (worklist.nonEmpty) {
       val block = worklist.dequeue()

--- a/src/main/scala/mjis/opt/NodeCollector.scala
+++ b/src/main/scala/mjis/opt/NodeCollector.scala
@@ -25,36 +25,4 @@ object NodeCollector {
     })
     blocks
   }
-
-  def getBlocksInReverseBackEdgesPostOrder(g: Graph): Seq[Block] = {
-    val dominators = g.getDominators
-    val postOrder = ArrayBuffer[Block]()
-    val edges = g.getBlockBackEdges
-
-    def visit(block: Block): Unit = {
-      if (!block.blockVisited) {
-        block.markBlockVisited()
-
-        // Make sure the last block of a loop in the linear order is always the one with a back jump
-        // to the header. To ensure this, successors that lead into nested loops are visited last (so
-        // they appear first in the reversed post order).
-        val backEdgeDominators = block.getPreds.flatMap(_.block match {
-          case b: Block if dominators(b).contains(block) => Some(dominators(b))
-          case _ => None
-        }).foldLeft(Set[Block]())(_ union _)
-        val (loopSuccessors, nonLoopSuccessors) = edges(block).partition(backEdgeDominators.contains)
-        nonLoopSuccessors.foreach(visit)
-        loopSuccessors.foreach(visit)
-        postOrder += block
-      }
-    }
-
-    g.incBlockVisited()
-
-    postOrder += g.getEndBlock
-    g.getEndBlock.markBlockVisited()
-
-    visit(g.getStartBlock)
-    postOrder.reverse
-  }
 }

--- a/src/main/scala/mjis/util/Digraph.scala
+++ b/src/main/scala/mjis/util/Digraph.scala
@@ -1,0 +1,40 @@
+package mjis.util
+
+import scala.collection.Map
+import scala.collection.mutable
+import mjis.util.MapExtensions._
+
+import scala.collection.mutable.ArrayBuffer
+
+object Digraph {
+  def getTopologicalSorting[V](edges: Map[V, Seq[V]], start: V, nodes: Option[Set[V]] = None, visited: mutable.Set[V] = mutable.Set[V]()): Seq[V] = {
+    val result = ArrayBuffer[V]()
+    def walk(n: V): Unit = if (nodes.forall(_(n)) && !visited(n)) {
+      visited += n
+      edges.getOrElse(n, Seq()).foreach(walk)
+      result += n
+    }
+    walk(start)
+    result.reverse
+  }
+
+  def transpose[V](edges: Map[V, Seq[V]]): mutable.Map[V, ArrayBuffer[V]] = {
+    val res = mutable.ListMap[V, ArrayBuffer[V]]().withPersistentDefault(_ => ArrayBuffer[V]())
+    for ((src, dests) <- edges) dests.foreach(res(_) += src)
+    res
+  }
+
+  /** Kosaraju's algorithm. Returns SCCs and their respective dominating node (for reducible graphs)
+    * in topological order, starting with the one containing `start`.
+    */
+  def findStronglyConnectedComponents[V](edges: Map[V, Seq[V]], start: V, nodes: Option[Set[V]] = None): Seq[(V, Set[V])] = {
+    val visited = mutable.Set[V]()
+    val transposed = transpose(edges)
+    getTopologicalSorting(edges, start, nodes).flatMap { n =>
+      getTopologicalSorting(transposed, n, nodes, visited) match {
+        case Seq() => None
+        case scc => Some((scc.head, scc.toSet))
+      }
+    }
+  }
+}

--- a/src/main/scala/mjis/util/MapExtensions.scala
+++ b/src/main/scala/mjis/util/MapExtensions.scala
@@ -3,7 +3,7 @@ package mjis.util
 import scala.collection.mutable
 
 object MapExtensions {
-  implicit class MapExtensions[A, B](map: mutable.Map[A, B]) {
+  implicit class Impl[A, B](map: mutable.Map[A, B]) {
     def withPersistentDefault(default: A => B) = map.withDefault(key => {
       val value = default(key)
       map += key -> value

--- a/src/test/scala/mjis/util/DigraphTest.scala
+++ b/src/test/scala/mjis/util/DigraphTest.scala
@@ -1,0 +1,28 @@
+package mjis.util
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class DigraphTest extends FlatSpec with Matchers {
+  "findStronglyConnectedComponents" should "do its job" in {
+    /*
+      1 -> 2 -> 3 -> 4 -> 5 <-> 6
+           |    |    |
+           |<32 <    |
+           |         |
+           |<   42   <
+     */
+
+    val edges = Seq(1 -> 2, 2 -> 3,   3 -> 4, 4 ->5, 5 -> 6,
+                            3 -> 32, 32 -> 2,        6 -> 5,
+                            4 -> 42, 42 -> 2)
+    val res = Digraph.findStronglyConnectedComponents(
+      edges.groupBy(_._1).mapValues(_.map(_._2)),
+      1
+    )
+    res shouldBe Seq(
+      (1, Set(1)),
+      (2, Set(2, 3, 4, 32, 42)),
+      (5, Set(5, 6))
+    )
+  }
+}


### PR DESCRIPTION
The only (small) generated assembler difference is that Bad nodes may now induce critical edges elimination. But I guess handling/not emitting dead code is a general problem still to be tackled.