### PR TITLE
Improve data structures and algorithms for LivenessIntervals.

### DIFF
--- a/src/main/scala/mjis/RegisterAllocator.scala
+++ b/src/main/scala/mjis/RegisterAllocator.scala
@@ -169,7 +169,7 @@ class FunctionRegisterAllocator(function: AsmFunction,
 
         for ((op, spec) <- getRegisterUsages(instr)) {
           // Physical registers need no usage information since they cannot be spilled
-          if (op.regNr >= 0) interval(op).usages += RegisterUsage(instrPos, spec)
+          if (op.regNr >= 0) interval(op).addUsage(instrPos, spec)
 
           if (spec.contains(WRITE)) {
             // definition -- shorten live range
@@ -250,7 +250,7 @@ class FunctionRegisterAllocator(function: AsmFunction,
 
         spilledInterval.nextUsage(position) match {
           // TODO: Possible optimization: split at first use position *that requires a register*
-          case Some(nextUsage) => splitInterval(spilledInterval, nextUsage.position)
+          case Some(nextUsage) => splitInterval(spilledInterval, nextUsage.getKey)
           case None =>
         }
       }


### PR DESCRIPTION
e.g. intersection test of two liveness intervals is now linear
instead of quadratic in the number of ranges. Gave a ~15% speedup
for register allocation when compiling fannkuch.