### PR TITLE
Re-optimize block order after register allocation

### DIFF
--- a/src/main/scala/mjis/AssemblerFileGenerator.scala
+++ b/src/main/scala/mjis/AssemblerFileGenerator.scala
@@ -26,9 +26,7 @@ abstract class AssemblerFileGenerator(config: Config) extends Phase[Unit] {
     fw.flush()
   }
 
-  val findings = List()
-
-  def dumpResult(writer: BufferedWriter) = {
+  override def dumpResult(writer: BufferedWriter) = {
     Source.fromFile(config.asmOutFile.toFile).foreach(writer.write(_))
   }
 }
@@ -88,8 +86,8 @@ class MjisAssemblerFileGenerator(input: AsmProgram, config: Config) extends Asse
       emit(".p2align 4,,15")
       emit(s"${function.name}:", indent = false)
 
-      for (Seq(pred, block) <- (null +: function.basicBlocks).sliding(2)) {
-        if (block.predecessors.flatten.exists(_ != pred)) emit(".p2align 4,,15")
+      for (block <- function.basicBlocks) {
+        if (function.isLoopHeader(block)) emit(".p2align 4,,15")
         emit(
           (block match {
             case function.prologue => "# Prologue"

--- a/src/main/scala/mjis/BlockOrdering.scala
+++ b/src/main/scala/mjis/BlockOrdering.scala
@@ -1,0 +1,59 @@
+package mjis
+
+import mjis.asm._
+import mjis.util.{SCCLoop, SCCLeaf, SCCTreeNode, Digraph}
+
+class BlockOrdering(program: AsmProgram) extends Phase[AsmProgram] {
+
+  private def optimizeBlockOrder(function: AsmFunction) = {
+    val g = new Digraph(function.basicBlocks.map(b => b -> b.successors).toMap)
+
+    def rec(scc: SCCTreeNode[AsmBasicBlock]): Seq[AsmBasicBlock] = scc match {
+      case SCCLeaf(block) => Seq(block)
+      case l@SCCLoop(_, tree) =>
+        val layoutedComponents = tree.map(rec)
+        val inSCC = scc.nodes.toSet
+        val componentOfNode = tree.flatMap(c => c.nodes.map(_ -> c)).toMap
+        // try to put loop conditions last
+        val orderedComponents = tree.find {
+          case SCCLeaf(block) => block.successors.size > 1 && block.successors.exists(!inSCC(_))
+          case _ => false
+        } match {
+          case Some(cond) =>
+            val loopSucc = cond.nodes(0).successors.find(inSCC).get
+            // use tree rooted at `loopSucc` and append `cond`
+            g.getCondensationGraph(tree).getTopologicalSorting(componentOfNode(loopSucc)).filter(_ != cond) :+ cond
+          case None => tree
+        }
+        orderedComponents.map(rec).flatten
+    }
+
+    function.basicBlocks = g.getSCCTree(function.prologue).map(rec).flatten.toList
+  }
+
+  override def getResult(): AsmProgram = {
+    for (function <- program.functions) {
+      optimizeBlockOrder(function)
+      for (Seq(block, next) <- function.basicBlocks.sliding(2)) {
+        def jmp(dest: AsmBasicBlock) = dest match {
+          case `next` => Seq()
+          case _ => Seq(asm.Jmp(BasicBlockOperand(dest)))
+        }
+        block.controlFlowInstructions ++= (block.successors.size match {
+          case 2 =>
+            // Prefer fallthrough
+            if (block.successors(0) == next)
+              Seq(JmpConditional(BasicBlockOperand(block.successors(1)), block.relation, negate = true))
+            else {
+              Seq(JmpConditional(BasicBlockOperand(block.successors(0)), block.relation, negate = false)) ++ jmp(block.successors(1))
+            }
+          case 1 => jmp(block.successors(0))
+          case 0 => Seq()
+          case _ => ???
+        })
+      }
+    }
+    program
+  }
+
+}

--- a/src/main/scala/mjis/Compiler.scala
+++ b/src/main/scala/mjis/Compiler.scala
@@ -15,7 +15,7 @@ object Compiler {
   type Pipeline = List[Class[_ <: Phase[_]]]
   private val defaultPipeline: Pipeline = List(classOf[Lexer], classOf[Parser], classOf[Namer],
     classOf[Typer], classOf[FirmConstructor], classOf[Optimizer], classOf[CodeGenerator], classOf[RegisterAllocator],
-    classOf[MjisAssemblerFileGenerator], classOf[GccRunner])
+    classOf[BlockOrdering], classOf[MjisAssemblerFileGenerator], classOf[GccRunner])
   private val firmCompilePipeline: Pipeline = List(classOf[Lexer], classOf[Parser], classOf[Namer],
     classOf[Typer], classOf[FirmConstructor], classOf[Optimizer], classOf[FirmAssemblerFileGenerator],
     classOf[GccRunner])

--- a/src/main/scala/mjis/Optimizer.scala
+++ b/src/main/scala/mjis/Optimizer.scala
@@ -17,11 +17,11 @@ class Optimizer(input: Unit) extends Phase[Unit] {
   }
 
   private def removeCriticalEdges(g: Graph): Unit = {
-    val backEdges = Digraph.transpose(g.getBlockEdges)
+    val cfGraph = g.getBlockGraph.transposed
     for (block <- NodeCollector.fromBlockWalk(g.walkBlocks))
       if (block.getPreds.count(!_.isInstanceOf[Bad]) > 1)
         for ((pred, idx) <- block.getPreds.zipWithIndex if !pred.isInstanceOf[Bad])
-          if (backEdges(pred.block).size > 1) {
+          if (cfGraph.edges(pred.block).size > 1) {
             val newBlock = g.newBlock(Array(pred))
             block.setPred(idx, g.newJmp(newBlock))
           }

--- a/src/main/scala/mjis/Phase.scala
+++ b/src/main/scala/mjis/Phase.scala
@@ -9,10 +9,10 @@ import java.io.BufferedWriter
 trait Phase[+O] {
   def name: String = getClass.getSimpleName.toLowerCase
   protected def getResult(): O
-  def dumpResult(writer: BufferedWriter): Unit
+  def dumpResult(writer: BufferedWriter): Unit = {}
   lazy val result: O = getResult()
   def forceResult(): Unit = result
-  def findings: List[Finding]
+  def findings: List[Finding] = List()
 }
 
 trait AnalysisPhase[O] extends Phase[O] {

--- a/src/main/scala/mjis/RegisterAllocator.scala
+++ b/src/main/scala/mjis/RegisterAllocator.scala
@@ -129,13 +129,6 @@ class FunctionRegisterAllocator(function: AsmFunction,
     withPersistentDefault(_ => ListBuffer[(Operand, Operand)]())
 
 
-  private def isLoopHeader(b: AsmBasicBlock) =
-    function.basicBlocks.drop(function.basicBlocks.indexOf(b)).exists(s => s.successors.contains(b))
-
-  private def getLoopEnd(b: AsmBasicBlock) =
-    function.basicBlocks.filter(s => s.successors.contains(b)).last
-
-
   private def buildLivenessIntervals() = {
     // Records for each block which variables are live at its beginning.
     val liveIn = mutable.Map[AsmBasicBlock, Set[RegisterOperand]]().withDefaultValue(Set())
@@ -195,8 +188,8 @@ class FunctionRegisterAllocator(function: AsmFunction,
       // Phi functions are a definition for their destination operands
       live --= b.phis.map(_.dest)
 
-      if (isLoopHeader(b)) {
-        val loopEnd = getLoopEnd(b)
+      if (function.isLoopHeader(b)) {
+        val loopEnd = function.getLoopEnd(b)
         for (op <- live) interval(op).addRange(blockStartPos(b), blockEndPos(loopEnd))
       }
 

--- a/src/main/scala/mjis/asm/AsmProgram.scala
+++ b/src/main/scala/mjis/asm/AsmProgram.scala
@@ -1,5 +1,7 @@
 package mjis.asm
 
+import firm.Relation
+
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.ArrayBuffer
 
@@ -10,6 +12,8 @@ class AsmBasicBlock(val nr: Int = -1) {
   val controlFlowInstructions = ListBuffer[Instruction]()
   def allInstructions = instructions.iterator ++ controlFlowInstructions.iterator
 
+  /** For successors.size == 2: Jump to successors(0) iff relation is fulfilled */
+  var relation: Relation = null
   val successors = ArrayBuffer[AsmBasicBlock]()
   // `predecessors` contains None entries for blocks that are not in the function's list of basic blocks
   // (because they are unreachable) and Bad predecessors.
@@ -26,6 +30,11 @@ class AsmFunction(val name: String) {
 
   def controlFlowEdges: Seq[(AsmBasicBlock, AsmBasicBlock)] =
     this.basicBlocks.flatMap(b => b.predecessors.flatten.map((_, b)))
+
+  def isLoopHeader(b: AsmBasicBlock) =
+    basicBlocks.drop(basicBlocks.indexOf(b)).exists(_.successors.contains(b))
+
+  def getLoopEnd(b: AsmBasicBlock) = basicBlocks.filter(_.successors.contains(b)).last
 }
 
 class AsmProgram {

--- a/src/main/scala/mjis/opt/DataFlowAnalysis.scala
+++ b/src/main/scala/mjis/opt/DataFlowAnalysis.scala
@@ -30,7 +30,7 @@ object DataFlowAnalysis {
     val m = mutable.Map[Block, A]().withDefaultValue(bot)
 
     val worklist = NodeCollector.fromBlockWalk(g.walkBlocks).to[mutable.Queue]
-    val backEdges = Digraph.transpose(g.getBlockEdges)
+    val cfGraph = g.getBlockGraph.transposed
 
     while (worklist.nonEmpty) {
       val block = worklist.dequeue()
@@ -38,7 +38,7 @@ object DataFlowAnalysis {
 
       if (value != m(block)) {
         m(block) = value
-        backEdges(block).foreach(worklist.enqueue(_))
+        cfGraph.edges(block).foreach(worklist.enqueue(_))
       }
     }
 

--- a/src/main/scala/mjis/opt/FirmExtensions.scala
+++ b/src/main/scala/mjis/opt/FirmExtensions.scala
@@ -3,6 +3,7 @@ package mjis.opt
 import firm._
 import firm.nodes._
 import mjis.opt.FirmExtractors._
+import mjis.util.Digraph
 import scala.collection.JavaConversions._
 import scala.collection.immutable.ListMap
 
@@ -26,10 +27,10 @@ object FirmExtensions {
           GraphBase.exchange(proj, node.getPred(0))
     }
 
-    def getBlockEdges: Map[Block, Seq[Block]] = ListMap(
+    def getBlockGraph: Digraph[Block] = new Digraph(ListMap(
       NodeCollector.fromBlockWalk(g.walkBlocks)
       .map(b => b -> b.getPreds.map(_.block).filter(_ != null).toSeq): _*
-    )
+    ))
 
     def getDominators: Map[Block, Set[Block]] = {
       DataFlowAnalysis.iterateBlocks[Set[Block]](g, NodeCollector.fromBlockWalk(g.walkBlocks).toSet,

--- a/src/main/scala/mjis/util/Digraph.scala
+++ b/src/main/scala/mjis/util/Digraph.scala
@@ -6,10 +6,15 @@ import mjis.util.MapExtensions._
 
 import scala.collection.mutable.ArrayBuffer
 
-object Digraph {
-  def getTopologicalSorting[V](edges: Map[V, Seq[V]], start: V, nodes: Option[Set[V]] = None, visited: mutable.Set[V] = mutable.Set[V]()): Seq[V] = {
+abstract class SCCTreeNode[V](val nodes: Seq[V])
+case class SCCLeaf[V](node: V) extends SCCTreeNode[V](Seq(node))
+case class SCCLoop[V](dominator: V, tree: Seq[SCCTreeNode[V]]) extends SCCTreeNode(tree.flatMap(_.nodes))
+
+class Digraph[V](val edges: Map[V, Seq[V]]) {
+ 
+  def getTopologicalSorting(start: V, visited: mutable.Set[V] = mutable.Set[V]()): Seq[V] = {
     val result = ArrayBuffer[V]()
-    def walk(n: V): Unit = if (nodes.forall(_(n)) && !visited(n)) {
+    def walk(n: V): Unit = if (!visited(n)) {
       visited += n
       edges.getOrElse(n, Seq()).foreach(walk)
       result += n
@@ -18,23 +23,46 @@ object Digraph {
     result.reverse
   }
 
-  def transpose[V](edges: Map[V, Seq[V]]): mutable.Map[V, ArrayBuffer[V]] = {
-    val res = mutable.ListMap[V, ArrayBuffer[V]]().withPersistentDefault(_ => ArrayBuffer[V]())
-    for ((src, dests) <- edges) dests.foreach(res(_) += src)
-    res
+  def transposed: Digraph[V] = {
+    val reverse = mutable.ListMap[V, ArrayBuffer[V]]().withPersistentDefault(_ => ArrayBuffer[V]())
+    for ((src, dests) <- edges) dests.foreach(reverse(_) += src)
+    new Digraph(reverse)
   }
+
+  def getSubgraph(nodes: Set[V]): Digraph[V] = new Digraph(edges.flatMap {
+    case (src, dests) if nodes(src) => Some(src -> dests.filter(nodes))
+    case _ => None
+  })
 
   /** Kosaraju's algorithm. Returns SCCs and their respective dominating node (for reducible graphs)
     * in topological order, starting with the one containing `start`.
     */
-  def findStronglyConnectedComponents[V](edges: Map[V, Seq[V]], start: V, nodes: Option[Set[V]] = None): Seq[(V, Set[V])] = {
+  def findStronglyConnectedComponents(start: V): Seq[(V, Set[V])] = {
     val visited = mutable.Set[V]()
-    val transposed = transpose(edges)
-    getTopologicalSorting(edges, start, nodes).flatMap { n =>
-      getTopologicalSorting(transposed, n, nodes, visited) match {
+    val transposed = this.transposed
+    getTopologicalSorting(start).flatMap { n =>
+      transposed.getTopologicalSorting(n, visited) match {
         case Seq() => None
         case scc => Some((scc.head, scc.toSet))
       }
     }
   }
+
+  def getSCCTree(start: V): Seq[SCCTreeNode[V]] = findStronglyConnectedComponents(start).map {
+    case (_, scc) if scc.size == 1 => SCCLeaf[V](scc.head)
+    case (dominator, scc) =>
+      // break the cycle
+      val tree = new Digraph(for ((src, dests) <- getSubgraph(scc).edges) yield src -> dests.filter(_ != dominator))
+      SCCLoop[V](dominator, tree.getSCCTree(dominator))
+  }
+
+  def getCondensationGraph(components: Seq[SCCTreeNode[V]]): Digraph[SCCTreeNode[V]] = {
+    val componentOfBlock = components.flatMap(c => c.nodes.map(_ -> c)).toMap
+    def outEdges(c: SCCTreeNode[V]): Seq[SCCTreeNode[V]] =
+      c.nodes.flatMap(n => edges(n).flatMap(componentOfBlock.get))
+        .distinct
+        .filter(_ != c)
+    new Digraph(components.map(c => c -> outEdges(c)).toMap)
+  }
+
 }

--- a/src/test/scala/mjis/CodeGeneratorTest.scala
+++ b/src/test/scala/mjis/CodeGeneratorTest.scala
@@ -231,7 +231,7 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
         |  movb %dl, %REG0{1}  # argB
         |.L0:
         |  cmpb $1, %REG0{1}
-        |  jne .L2
+        |  je .L2
         |.L1:
         |  jmp .L3
         |.L2:
@@ -248,17 +248,17 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
         |  movl %esi, %REG0{4}
         |.L0:
         |  cmpl $0, %REG0{4}
-        |  jle .L2
+        |  jg .L2
         |.L1:
-        |  movl $1, %eax
+        |  movl $0, %eax
         |  jmp .L3
         |.L2:
-        |  movl $0, %eax
+        |  movl $1, %eax
         |.L3:
         |  ret"""))
   }
 
-  it should "use unconditional jumps for loop iterations" in {
+  it should "generate good loop code" in {
     fromMembers(
       """public boolean foo() {
         |  while (foo());
@@ -268,23 +268,23 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
       """_4Test_foo:
       |  movq %rdi, %REG0{8}
       |.L0:
+      |  jmp .L2
       |.L1:
+      |.L2:
       |  movq %REG0{8}, %rdi
       |  call _4Test_foo
       |  movb %al, %REG1{1}
       |  cmpb $1, %REG1{1}
-      |  jne .L3
-      |.L2:
-      |  jmp .L1
+      |  je .L1
       |.L3:
+      |  jmp .L5
       |.L4:
+      |.L5:
       |  movq %REG0{8}, %rdi
       |  call _4Test_foo
       |  movb %al, %REG2{1}
       |  cmpb $1, %REG2{1}
-      |  je .L6
-      |.L5:
-      |  jmp .L4
+      |  jne .L4
       |.L6:
       |  movb $1, %al
       |.L7:

--- a/src/test/scala/mjis/CompilerTestMatchers.scala
+++ b/src/test/scala/mjis/CompilerTestMatchers.scala
@@ -163,7 +163,9 @@ trait CompilerTestMatchers {
   class CodeGeneratorMatcher(expected: String) extends Matcher[String] {
     override def apply(code: String): MatchResult = {
       val codeGenerator = assertExec[CodeGenerator](code)
-      val asmGenerator = new MjisAssemblerFileGenerator(codeGenerator.resultProgram, null)
+      // add jumps
+      val program = new BlockOrdering(codeGenerator.resultProgram).result
+      val asmGenerator = new MjisAssemblerFileGenerator(program, null)
       val generatedCode = asmGenerator.generateCode()
 
       val fw = new BufferedWriter(new FileWriter("codegen.s", /* append */ false))

--- a/src/test/scala/mjis/util/DigraphTest.scala
+++ b/src/test/scala/mjis/util/DigraphTest.scala
@@ -3,26 +3,63 @@ package mjis.util
 import org.scalatest.{Matchers, FlatSpec}
 
 class DigraphTest extends FlatSpec with Matchers {
-  "findStronglyConnectedComponents" should "do its job" in {
-    /*
-      1 -> 2 -> 3 -> 4 -> 5 <-> 6
-           |    |    |
-           |<32 <    |
-           |         |
-           |<   42   <
-     */
+  /*
+    0 -> 1 -> 2 -> 3 -> 4 -> 5 <-> 6
+         |    |    |    |
+         |    |<32 <    |
+         |              |
+         |<     41      <
+   */
+  val edges = Seq(0 -> 1, 1 -> 2, 2 -> 3,   3 -> 4, 4 ->5, 5 -> 6,
+                                  3 -> 32, 32 -> 2,        6 -> 5,
+                              4 -> 41, 41 -> 1)
+  val g = new Digraph(edges.groupBy(_._1).mapValues(_.map(_._2)))
 
-    val edges = Seq(1 -> 2, 2 -> 3,   3 -> 4, 4 ->5, 5 -> 6,
-                            3 -> 32, 32 -> 2,        6 -> 5,
-                            4 -> 42, 42 -> 2)
-    val res = Digraph.findStronglyConnectedComponents(
-      edges.groupBy(_._1).mapValues(_.map(_._2)),
-      1
-    )
-    res shouldBe Seq(
-      (1, Set(1)),
-      (2, Set(2, 3, 4, 32, 42)),
+  "findStronglyConnectedComponents" should "do its job" in {
+    g.findStronglyConnectedComponents(0) shouldBe Seq(
+      (0, Set(0)),
+      (1, Set(1, 2, 3, 4, 32, 41)),
       (5, Set(5, 6))
+    )
+  }
+
+  "getSCCTree" should "do its job" in {
+    g.getSCCTree(0) shouldBe Seq(
+      SCCLeaf(0),
+      SCCLoop(1, Seq(
+        SCCLeaf(1),
+        SCCLoop(2, Seq(
+          SCCLeaf(2),
+          SCCLeaf(3),
+          SCCLeaf(32)
+        )),
+        SCCLeaf(4),
+        SCCLeaf(41)
+      )),
+      SCCLoop(5, Seq(
+        SCCLeaf(5),
+        SCCLeaf(6)
+      ))
+    )
+  }
+
+  "getCondensationGraph" should "do its job" in {
+    val tree = g.getSCCTree(0)
+    g.getCondensationGraph(tree).edges
+      // identify by dominator node
+      .map(e => (e._1.nodes.head, e._2.map(_.nodes.head))) shouldBe Map(
+      0 -> Seq(1),
+      1 -> Seq(5),
+      5 -> Seq()
+    )
+
+    g.getCondensationGraph(tree(1).asInstanceOf[SCCLoop[Int]].tree).edges
+      // identify by dominator node
+      .map(e => (e._1.nodes.head, e._2.map(_.nodes.head))) shouldBe Map(
+      1 -> Seq(2),
+      2 -> Seq(4),
+      4 -> Seq(41),
+      41 -> Seq(1)
     )
   }
 }


### PR DESCRIPTION
```
 perf stat ./a.out                     
556355
51

 Performance counter stats for './a.out':

       5234.982690      task-clock (msec)         #    1.000 CPUs utilized          
                12      context-switches          #    0.002 K/sec                  
                 8      cpu-migrations            #    0.002 K/sec                  
                 4      page-faults               #    0.001 K/sec                  
    16,697,532,792      cycles                    #    3.190 GHz                    
     4,289,009,585      stalled-cycles-frontend   #   25.69% frontend cycles idle   
   <not supported>      stalled-cycles-backend   
    30,563,451,088      instructions              #    1.83  insns per cycle        
                                                  #    0.14  stalled cycles per insn
     3,066,129,977      branches                  #  585.700 M/sec                  
       184,433,206      branch-misses             #    6.02% of all branches        

       5.232931610 seconds time elapsed
```
```
 perf stat ./master
556355
51

 Performance counter stats for './master':

       5589.592506      task-clock (msec)         #    1.001 CPUs utilized          
                 6      context-switches          #    0.001 K/sec                  
                14      cpu-migrations            #    0.003 K/sec                  
                 5      page-faults               #    0.001 K/sec                  
    17,858,086,103      cycles                    #    3.195 GHz                    
     3,896,616,843      stalled-cycles-frontend   #   21.82% frontend cycles idle   
   <not supported>      stalled-cycles-backend   
    32,291,016,551      instructions              #    1.81  insns per cycle        
                                                  #    0.12  stalled cycles per insn
     4,238,527,228      branches                  #  758.289 M/sec                  
       208,974,701      branch-misses             #    4.93% of all branches        

       5.586453310 seconds time elapsed
```