### PR TITLE
Properly handle NULL array accesses in optimizations

### DIFF
--- a/src/main/scala/mjis/opt/ConstantFolding.scala
+++ b/src/main/scala/mjis/opt/ConstantFolding.scala
@@ -66,6 +66,7 @@ object ConstantFolding extends Optimization(needsBackEdges = true) {
         case _: Shl => liftBin(_.shl(_))
         case _: Minus => liftUnary(_.neg, values(0))
         case cmp: Cmp => liftBin((x, y) => fromBool(x.compare(y).contains(cmp.getRelation)))
+        case ConvExtr(ConstExtr(c)) => new TargetValue(c, node.getMode)
         case _ => conflicting
       }
     })

--- a/src/main/scala/mjis/opt/Identities.scala
+++ b/src/main/scala/mjis/opt/Identities.scala
@@ -26,7 +26,11 @@ object Identities extends Optimization(needsBackEdges = true) {
   def _optimize(g: Graph): Unit = {
     g.walkTopological(new NodeVisitor.Default {
       override def defaultVisit(node: Node): Unit = node match {
-        case n@AddExtr(x, ConstExtr(0)) => exchange(n, x)
+        case n@AddExtr(x, ConstExtr(0)) =>
+          if (n.getMode != x.getMode)
+            exchange(n, g.newConv(n.getBlock, x, n.getMode))
+          else
+            exchange(n, x)
         case n@MulExtr(x, ConstExtr(1)) => exchange(n, x)
         case n@MulExtr(x, ConstExtr(PowerOfTwo(exp))) =>
           exchange(n, g.newShl(n.getBlock, x, g.newConst(exp, Mode.getIu), n.getMode))


### PR DESCRIPTION
Without this, certain interactions with inlining will result in Store or Load nodes complaining about loading addresses that have a mode != P64.