### PR TITLE
Split Optimizations into graph-based and node-based ones

### DIFF
--- a/src/main/scala/mjis/opt/CommonSubexpressionElimination.scala
+++ b/src/main/scala/mjis/opt/CommonSubexpressionElimination.scala
@@ -5,32 +5,31 @@ import firm.nodes._
 import scala.collection.mutable
 import scala.collection.JavaConversions._
 
-object CommonSubexpressionElimination extends Optimization {
+object CommonSubexpressionElimination extends NodeBasedOptimization {
 
-  def _optimize(g: Graph): Unit = {
-    // map from data uniquely identifying a subexpression to the representing node
-    val m = mutable.Map[AnyRef, Node]()
+  // map from data uniquely identifying a subexpression to the representing node
+  val m = mutable.Map[AnyRef, Node]()
 
-    def getData: PartialFunction[Node, AnyRef] = {
-      case c: Const => c.getTarval.asLong.underlying()
-      case _: Add | _: Sub | _: Minus | _: Mul | _: Div | _: Mod | _: Sel | _: Conv | _: Cond | _: Phi => null // no data
-      case proj: Proj => (proj.getPred, proj.getNum)
-      case cmp: Cmp => cmp.getRelation
-      case addr: Address => addr.getEntity
-      case member: Member => member.getEntity
-    }
+  def getData: PartialFunction[Node, AnyRef] = {
+    case c: Const => c.getTarval.asLong.underlying()
+    case _: Add | _: Sub | _: Minus | _: Mul | _: Div | _: Mod | _: Sel | _: Conv | _: Cond | _: Phi => null // no data
+    case proj: Proj => (proj.getPred, proj.getNum)
+    case cmp: Cmp => cmp.getRelation
+    case addr: Address => addr.getEntity
+    case member: Member => member.getEntity
+  }
 
-    g.walkPostorder(new NodeVisitor.Default {
-      override def defaultVisit(node: Node): Unit = getData.lift(node) match {
-        case Some(nodeData) =>
-          val data = (node.getOpCode, node.getBlock, node.getMode, node.getPreds.toList, nodeData)
-          m.get(data) match {
-            case Some(n2) => exchange(node, n2)
-            case None => m += data -> node
-          }
-        case None =>
+  override def beforeOptimize(g: Graph) = m.clear()
+
+  override def _optimize(g: Graph, node: Node) = getData.lift(node) match {
+    case Some(nodeData) =>
+      val data = (node.getOpCode, node.getBlock, node.getMode, node.getPreds.toList, nodeData)
+      m.get(data) match {
+        case Some(`node`) =>
+        case Some(n2) => exchange(node, n2)
+        case None => m(data) = node
       }
-    })
+    case None =>
   }
 
 }

--- a/src/main/scala/mjis/opt/ConstantFolding.scala
+++ b/src/main/scala/mjis/opt/ConstantFolding.scala
@@ -6,7 +6,7 @@ import mjis.opt.FirmExtractors._
 import mjis.opt.FirmExtensions._
 
 
-object ConstantFolding extends Optimization(needsBackEdges = true) {
+object ConstantFolding extends DeferredOptimization(needsBackEdges = true) {
 
   private val unknown = TargetValue.getUnknown
   private val conflicting = TargetValue.getBad
@@ -34,7 +34,7 @@ object ConstantFolding extends Optimization(needsBackEdges = true) {
 
   private def fromBool(b: Boolean): TargetValue = if (b) TargetValue.getBTrue else TargetValue.getBFalse
 
-  override def _optimize(g: Graph): Unit = {
+  override def __optimize(g: Graph): Unit = {
     val tarvals = DataFlowAnalysis.iterate[TargetValue](g, unknown, (node, values) => {
       def liftBin(op: (TargetValue, TargetValue) => TargetValue) = liftBinary(op, values(0), values(1))
 
@@ -79,8 +79,7 @@ object ConstantFolding extends Optimization(needsBackEdges = true) {
           case _: Div | _: Mod =>
             // the Div / Mod node itself is not exchanged, instead its result Proj
             // will be replaced
-            g.killMemoryNode(node)
-            changed = true
+            killMemoryNode(node)
           case _: Proj if node.getMode == Mode.getX =>
             if (tarval == TargetValue.getBTrue)
               exchange(node, g.newJmp(node.getBlock))

--- a/src/main/scala/mjis/opt/FirmExtensions.scala
+++ b/src/main/scala/mjis/opt/FirmExtensions.scala
@@ -18,15 +18,6 @@ object FirmExtensions {
 
   implicit class GraphExt(g: Graph) {
 
-    /**
-     * "Deletes" a memory node by redirecting the graph's memory flow
-     */
-    def killMemoryNode(node: Node): Unit = node match {
-      case _: Div | _: Mod | _: Store | _: Load =>
-        for (proj@ProjExtr(_, Div.pnM /* == Mod.pnM == ... */) <- BackEdges.getOuts(node).map(_.node))
-          GraphBase.exchange(proj, node.getPred(0))
-    }
-
     def getBlockGraph: Digraph[Block] = new Digraph(ListMap(
       NodeCollector.fromBlockWalk(g.walkBlocks)
       .map(b => b -> b.getPreds.map(_.block).filter(_ != null).toSeq): _*

--- a/src/main/scala/mjis/opt/Identities.scala
+++ b/src/main/scala/mjis/opt/Identities.scala
@@ -5,7 +5,7 @@ import firm.nodes._
 import mjis.opt.FirmExtractors._
 import mjis.opt.FirmExtensions._
 
-object Identities extends Optimization(needsBackEdges = true) {
+object Identities extends NodeBasedOptimization() {
 
   private object PowerOfTwo {
     def unapply(x: Int): Option[Int] = {
@@ -23,28 +23,24 @@ object Identities extends Optimization(needsBackEdges = true) {
     }
   }
 
-  def _optimize(g: Graph): Unit = {
-    g.walkTopological(new NodeVisitor.Default {
-      override def defaultVisit(node: Node): Unit = node match {
-        case n@AddExtr(x, ConstExtr(0)) =>
-          if (n.getMode != x.getMode)
-            exchange(n, g.newConv(n.getBlock, x, n.getMode))
-          else
-            exchange(n, x)
-        case n@MulExtr(x, ConstExtr(1)) => exchange(n, x)
-        case n@MulExtr(x, ConstExtr(PowerOfTwo(exp))) =>
-          exchange(n, g.newShl(n.getBlock, x, g.newConst(exp, Mode.getIu), n.getMode))
-        case n@ProjExtr(div@DivExtr(x, ConstExtr(1)), Div.pnRes) =>
-          g.killMemoryNode(div)
-          exchange(n, x)
-        // x % 2^k ==/!= 0
-        case CmpExtr(Relation.Equal | Relation.UnorderedLessGreater, proj@ProjExtr(mod@ModExtr(x, ConstExtr(modulo@PowerOfTwo(_))), Mod.pnRes), ConstExtr(0)) =>
-          g.killMemoryNode(mod)
-          // |x % 2^k| = x & (modulo-1)
-          exchange(proj, g.newAnd(proj.getBlock, x, g.newConst(modulo-1, x.getMode), x.getMode))
-        case _ =>
-      }
-    })
+  override def _optimize(g: Graph, node: Node) = node match {
+    case n@AddExtr(x, ConstExtr(0)) =>
+      if (n.getMode != x.getMode)
+        exchange(n, g.newConv(n.getBlock, x, n.getMode))
+      else
+        exchange(n, x)
+    case n@MulExtr(x, ConstExtr(1)) => exchange(n, x)
+    case n@MulExtr(x, ConstExtr(PowerOfTwo(exp))) =>
+      exchange(n, g.newShl(n.getBlock, x, g.newConst(exp, Mode.getIu), n.getMode))
+    case n@ProjExtr(div@DivExtr(x, ConstExtr(1)), Div.pnRes) =>
+      killMemoryNode(div)
+      exchange(n, x)
+    // x % 2^k ==/!= 0
+    case CmpExtr(Relation.Equal | Relation.UnorderedLessGreater, proj@ProjExtr(mod@ModExtr(x, ConstExtr(modulo@PowerOfTwo(_))), Mod.pnRes), ConstExtr(0)) =>
+      killMemoryNode(mod)
+      // |x % 2^k| = x & (modulo-1)
+      exchange(proj, g.newAnd(proj.getBlock, x, g.newConst(modulo - 1, x.getMode), x.getMode))
+    case _ =>
   }
 
 }

--- a/src/main/scala/mjis/opt/LoopStrengthReduction.scala
+++ b/src/main/scala/mjis/opt/LoopStrengthReduction.scala
@@ -23,9 +23,9 @@ import mjis.opt.FirmExtensions._
  *   ptr += incr * sizeof(a[0]);
  * }
  */
-object LoopStrengthReduction extends Optimization(needsBackEdges = true) {
+object LoopStrengthReduction extends DeferredOptimization(needsBackEdges = true) {
 
-  override def _optimize(g: Graph): Unit = {
+  override def __optimize(g: Graph): Unit = {
     val inductionVars = g.getInductionVariables.map(v => v.value -> v).toMap[Node, InductionVariable]
     val dominators = g.getDominators
 
@@ -46,7 +46,7 @@ object LoopStrengthReduction extends Optimization(needsBackEdges = true) {
               g.newConst(v.incr.getTarval.asInt() * elementBytes, Mode.getIs),
               Mode.getP
             )
-            ptr.setPred(1, ptrIncrAdd)
+            setPred(ptr, 1, ptrIncrAdd)
             exchange(sel, ptr)
           }
         case None =>

--- a/src/main/scala/mjis/opt/Normalization.scala
+++ b/src/main/scala/mjis/opt/Normalization.scala
@@ -4,25 +4,20 @@ import firm._
 import firm.nodes._
 import mjis.opt.FirmExtractors._
 
-object Normalization extends Optimization {
+object Normalization extends NodeBasedOptimization {
 
-  override def _optimize(g: Graph): Unit = {
-    g.walkTopological(new NodeVisitor.Default {
-      override def defaultVisit(node: Node): Unit = node match {
-        case AddExtr(_: Const, _) | MulExtr(_: Const, _) =>
-          val pred0 = node.getPred(0)
-          node.setPred(0, node.getPred(1))
-          node.setPred(1, pred0)
-          changed = true
-        case SubExtr(x, ConstExtr(c)) =>
-          // x - c == x + (-c)
-          exchange(node, g.newAdd(node.getBlock, x, g.newConst(-c, node.getMode), node.getMode))
-        case SubExtr(ConstExtr(0), x) =>
-          // 0 - x = -x
-          exchange(node, g.newMinus(node.getBlock, x, node.getMode))
-        case _ =>
-      }
-    })
+  override def _optimize(g: Graph, node: Node): Unit = node match {
+    case AddExtr(_: Const, _) | MulExtr(_: Const, _) =>
+      val pred0 = node.getPred(0)
+      setPred(node, 0, node.getPred(1))
+      setPred(node, 1, pred0)
+    case SubExtr(x, ConstExtr(c)) =>
+      // x - c == x + (-c)
+      exchange(node, g.newAdd(node.getBlock, x, g.newConst(-c, node.getMode), node.getMode))
+    case SubExtr(ConstExtr(0), x) =>
+      // 0 - x = -x
+      exchange(node, g.newMinus(node.getBlock, x, node.getMode))
+    case _ =>
   }
 
 }

--- a/src/main/scala/mjis/opt/Optimization.scala
+++ b/src/main/scala/mjis/opt/Optimization.scala
@@ -4,8 +4,11 @@ import firm._
 import firm.nodes._
 import mjis.opt.FirmExtractors._
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 
 abstract class Optimization(needsBackEdges: Boolean = false) {
+
   def optimize(): Boolean = {
     // always optimize all graphs
     Program.getGraphs.toSeq.map(optimize).exists(b => b)
@@ -17,18 +20,78 @@ abstract class Optimization(needsBackEdges: Boolean = false) {
     changed = false
     if (needsBackEdges)
       BackEdges.enable(g)
-    try
-      _optimize(g)
-    finally
-      if (needsBackEdges)
-        BackEdges.disable(g)
+    _optimize(g)
+    if (needsBackEdges)
+      BackEdges.disable(g)
     changed
   }
 
-  protected def exchange(oldNode: Node, newNode: Node) = {
-    changed = true
+  protected def _optimize(g: Graph): Unit
+
+  protected def exchange(oldNode: Node, newNode: Node): Unit = {
     GraphBase.exchange(oldNode, newNode)
+    changed = true
+  }
+  protected def setPred(node: Node, idx: Int, pred: Node): Unit = {
+    node.setPred(idx, pred)
+    changed = true
   }
 
-  protected def _optimize(g: Graph): Unit
+  /**
+   * "Deletes" a memory node by redirecting the graph's memory flow
+   */
+  protected def killMemoryNode(node: Node): Unit = node match {
+    case _: Div | _: Mod | _: Store | _: Load =>
+      for (proj@ProjExtr(_, Div.pnM /* == Mod.pnM == ... */) <- BackEdges.getOuts(node).map(_.node))
+        exchange(proj, node.getPred(0))
+  }
+}
+
+abstract class DeferredOptimization(needsBackEdges: Boolean = false) extends Optimization(needsBackEdges) {
+
+  private val exchanges = mutable.Map[Node, Node]()
+  private val setPreds = ArrayBuffer[(Node, Int, Node)]()
+
+  private def getNewNode(oldNode: Node): Node = exchanges.get(oldNode).map(getNewNode).getOrElse(oldNode)
+
+  protected final override def _optimize(g: Graph): Unit = {
+    exchanges.clear()
+    setPreds.clear()
+
+    __optimize(g)
+
+    for ((node, idx, pred) <- setPreds) super.setPred(getNewNode(node), idx, getNewNode(pred))
+    for (oldNode <- exchanges.keys) super.exchange(oldNode, getNewNode(oldNode))
+  }
+
+  // I feel slightly silly, but full decorators would feel slightly sillier
+  protected def __optimize(g: Graph): Unit
+
+  protected override def exchange(oldNode: Node, newNode: Node): Unit = {
+    assert(oldNode != newNode)
+    exchanges(oldNode) = newNode
+  }
+  protected override def setPred(node: Node, idx: Int, pred: Node): Unit = setPreds += ((node, idx, pred))
+}
+
+abstract class NodeBasedOptimization() extends Optimization(needsBackEdges = true) {
+
+  private val queue = mutable.Queue[Node]()
+
+  protected final override def _optimize(g: Graph): Unit = {
+    beforeOptimize(g)
+    queue.clear()
+    queue ++= NodeCollector.fromWalk(g.walk)
+    while (queue.nonEmpty)
+      _optimize(g, queue.dequeue())
+  }
+
+  protected def beforeOptimize(g: Graph): Unit = {}
+  protected def _optimize(g: Graph, node: Node): Unit
+
+  protected override def exchange(oldNode: Node, newNode: Node): Unit = {
+    queue.dequeueAll(_ == oldNode)
+    queue ++= BackEdges.getOuts(oldNode).map(_.node)
+    super.exchange(oldNode, newNode)
+  }
 }

--- a/src/main/scala/mjis/opt/TrivialPhiElimination.scala
+++ b/src/main/scala/mjis/opt/TrivialPhiElimination.scala
@@ -4,29 +4,17 @@ import firm._
 import firm.nodes._
 import scala.collection.JavaConversions._
 
-object TrivialPhiElimination extends Optimization(needsBackEdges = true) {
+object TrivialPhiElimination extends NodeBasedOptimization() {
 
-  override def _optimize(g: Graph): Unit = {
-    g.walk(new NodeVisitor.Default {
-      override def visit(node: Phi): Unit = {
-        // skip memory phis
-        if (node.getMode == Mode.getM)
-          return
+  override def _optimize(g: Graph, node: Node): Unit = node match {
+    // skip memory phis
+    case _: Phi if node.getMode != Mode.getM =>
 
-        val preds = node.getPreds.toSet - node
+      val dependencies = node.getPreds.toSet - node
 
-        // trivial phi
-        if (preds.size == 1) {
-          val users = BackEdges.getOuts(node).toList
-          exchange(node, preds.head)
-          // recurse into all users which may have become trivial too
-          users.foreach(_.node match {
-            case phi: Phi => visit(phi)
-            case _ =>
-          })
-        }
-      }
-    })
+      if (dependencies.size == 1)
+        exchange(node, dependencies.head)
+    case _ =>
   }
 
 }


### PR DESCRIPTION
* Node-based optimizations can automatically be fixpoint-iterated and
  modify the graph immediately
* Graph-based optimizations with their own walkers need their changes
  to be deferred for the consistency of the remaining walk

Possible further optimization: Fold all node-based optimizations into
one fixpoint iteration