### PR TITLE
CodeGenerator: Remove inc/dec generation because Intel says so

### DIFF
--- a/src/main/scala/mjis/CodeGenerator.scala
+++ b/src/main/scala/mjis/CodeGenerator.scala
@@ -214,12 +214,6 @@ class CodeGenerator(a: Unit) extends Phase[AsmProgram] {
       node match {
         // special tree patterns that don't necessarily visit all predecessors
 
-        case n@AddExtr(incr, ConstExtr(1)) =>
-          toVisit ++= Seq(incr)
-          Seq(Mov(getOperand(incr), regOp(n)), Inc(regOp(n)))
-        case n@AddExtr(incr, ConstExtr(-1)) =>
-          toVisit ++= Seq(incr)
-          Seq(Mov(getOperand(incr), regOp(n)), Dec(regOp(n)))
         case n: nodes.Add => Seq(Lea(getAddressOperand(n, n.getMode.getSizeBytes), regOp(n)))
 
         case n: nodes.Load =>

--- a/src/main/scala/mjis/asm/Instruction.scala
+++ b/src/main/scala/mjis/asm/Instruction.scala
@@ -106,22 +106,10 @@ object Add {
   def unapply(instr: Instruction) = unapply2("add")(instr)
 }
 
-object Inc {
-  def apply(valueAndResult: Operand): Instruction =
-    new Instruction("inc", (valueAndResult, READ | WRITE | MEMORY))
-  def unapply(instr: Instruction) = unapply1("inc")(instr)
-}
-
 object Sub {
   def apply(subtrahend: Operand, minuendAndResult: Operand): Instruction =
     new Instruction("sub", (subtrahend, READ | CONST | MEMORY), (minuendAndResult, READ | WRITE | MEMORY))
   def unapply(instr: Instruction) = unapply2("sub")(instr)
-}
-
-object Dec {
-  def apply(valueAndResult: Operand): Instruction =
-    new Instruction("dec", (valueAndResult, READ | WRITE | MEMORY))
-  def unapply(instr: Instruction) = unapply1("dec")(instr)
 }
 
 object Neg {


### PR DESCRIPTION
Assembly/Compiler Coding Rule 33. (M impact, H generality) INC and DEC instructions should
be replaced with ADD or SUB instructions, because ADD and SUB overwrite all flags, whereas INC and
DEC do not, therefore creating false dependencies on earlier instructions that set the flags.