### PR TITLE
Poor man's instruction scheduling for induction variables

### DIFF
--- a/src/main/scala/mjis/opt/FirmExtensions.scala
+++ b/src/main/scala/mjis/opt/FirmExtensions.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.ListMap
  * ...
  * incrAdd = Add(value, incr)
  */
-case class InductionVariable(value: Phi, start: Const, incr: Const, incrAdd: Add)
+case class InductionVariable(value: Phi, start: Node, incr: Const, incrAdd: Add)
 
 object FirmExtensions {
 
@@ -33,9 +33,8 @@ object FirmExtensions {
     }
 
     def getInductionVariables: Seq[InductionVariable] = {
-      // TODO: recognize loop-invariant start and incr nodes instead of just constant ones
       NodeCollector.fromWalk(g.walk).map(node => node match {
-        case PhiExtr(start: Const, incrAdd@AddExtr(`node`, incr: Const)) =>
+        case PhiExtr(start, incrAdd@AddExtr(`node`, incr: Const)) =>
           Some(InductionVariable(node.asInstanceOf[Phi], start, incr, incrAdd.asInstanceOf[Add]))
         case _ => None
       }).flatten

--- a/src/main/scala/mjis/opt/LoopStrengthReduction.scala
+++ b/src/main/scala/mjis/opt/LoopStrengthReduction.scala
@@ -38,10 +38,7 @@ object LoopStrengthReduction extends DeferredOptimization(needsBackEdges = true)
           // the base address must be constant when entering the loop
           if (dominators(loopStartBlock).contains(sel.getPtr.block)) {
             val elementBytes = sel.getType.asInstanceOf[ArrayType].getElementType.getSizeBytes
-            val baseAddress = g.newAdd(loopStartBlock, sel.getPtr,
-              g.newConst(v.start.getTarval.asInt() * elementBytes, Mode.getIs),
-              Mode.getP
-            )
+            val baseAddress = g.newSel(loopStartBlock, sel.getPtr, v.start, sel.getType)
             val ptr = g.newPhi(condBlock, Array(baseAddress, g.newDummy(Mode.getP)), Mode.getP)
             val ptrIncrAdd = g.newAdd(v.incrAdd.block, ptr,
               g.newConst(v.incr.getTarval.asInt() * elementBytes, Mode.getIs),


### PR DESCRIPTION
master:
```
 Performance counter stats for './a.out':

       4223.180470      task-clock (msec)         #    1.001 CPUs utilized          
                 7      context-switches          #    0.002 K/sec                  
                 7      cpu-migrations            #    0.002 K/sec                  
                 4      page-faults               #    0.001 K/sec                  
    13,582,187,111      cycles                    #    3.216 GHz                    
     3,299,954,381      stalled-cycles-frontend   #   24.30% frontend cycles idle   
   <not supported>      stalled-cycles-backend   
    22,591,029,200      instructions              #    1.66  insns per cycle        
                                                  #    0.15  stalled cycles per insn
     3,065,913,294      branches                  #  725.973 M/sec                  
       188,173,583      branch-misses             #    6.14% of all branches        

       4.220724362 seconds time elapsed
```
PR:
```
 Performance counter stats for './a.out':

       4069.933783      task-clock (msec)         #    1.001 CPUs utilized          
                 9      context-switches          #    0.002 K/sec                  
                12      cpu-migrations            #    0.003 K/sec                  
                 5      page-faults               #    0.001 K/sec                  
    13,174,695,088      cycles                    #    3.237 GHz                    
     3,738,708,729      stalled-cycles-frontend   #   28.38% frontend cycles idle   
   <not supported>      stalled-cycles-backend   
    19,798,612,394      instructions              #    1.50  insns per cycle        
                                                  #    0.19  stalled cycles per insn
     3,065,890,602      branches                  #  753.302 M/sec                  
       185,026,644      branch-misses             #    6.04% of all branches        

       4.067644843 seconds time elapsed
```