### PR TITLE
Don't set current memory when generating Div and Mod nodes.

### DIFF
--- a/src/main/scala/mjis/FirmConstructor.scala
+++ b/src/main/scala/mjis/FirmConstructor.scala
@@ -294,14 +294,12 @@ class FirmConstructor(input: Program) extends Phase[Unit] {
               case Builtins.IntSubDecl => constr.newSub(args(0), args(1), Mode.getIs)
               case Builtins.IntMulDecl => constr.newMul(args(0), args(1), Mode.getIs)
               case Builtins.IntDivDecl =>
-                val divNode = constr.newDiv(constr.getCurrentMem, args(0), args(1),
+                val divNode = constr.newDiv(graph.getInitialMem, args(0), args(1),
                   Mode.getIs, op_pin_state.op_pin_state_pinned)
-                constr.setCurrentMem(constr.newProj(divNode, Mode.getM, firm.nodes.Div.pnM))
                 constr.newProj(divNode, Mode.getIs, firm.nodes.Div.pnRes)
               case Builtins.IntModDecl =>
-                val modNode = constr.newMod(constr.getCurrentMem, args(0), args(1),
+                val modNode = constr.newMod(graph.getInitialMem, args(0), args(1),
                   Mode.getIs, op_pin_state.op_pin_state_pinned)
-                constr.setCurrentMem(constr.newProj(modNode, Mode.getM, firm.nodes.Mod.pnM))
                 constr.newProj(modNode, Mode.getIs, firm.nodes.Mod.pnRes)
 
               case Builtins.IntMinusDecl =>

--- a/src/main/scala/mjis/opt/Identities.scala
+++ b/src/main/scala/mjis/opt/Identities.scala
@@ -30,7 +30,6 @@ object Identities extends NodeBasedOptimization() {
     // x % y == x - x / y * y (which is only useful if 'x / y' can be computed by fast division
     case n@ProjExtr(mod@ModExtr(x, y@ConstExtr(_)), Mod.pnRes) =>
       val div = g.newDiv(n.block, mod.asInstanceOf[Mod].getMem, x, y, n.getMode, op_pin_state.op_pin_state_pinned)
-      for (proj@ProjExtr(_, Mod.pnM) <- mod.successors) proj.setPred(0, div)
       exchange(n,
         g.newSub(n.block,
           x,

--- a/src/test/scala/mjis/FirmConstructorTest.scala
+++ b/src/test/scala/mjis/FirmConstructorTest.scala
@@ -119,10 +119,9 @@ class FirmConstructorTest extends FlatSpec with Matchers with BeforeAndAfter {
     val mDivMethodEntity = methodEntity("__expected__4Test_m_div", IntType, Seq())
     val mDiv = FirmGraphTestHelper.buildFirmGraph(mDivMethodEntity,
       intArithmeticFirm(
-        """mem = Proj M M, start
-          |divmod = Div Is, mem, const1, const2
+        """mem_before_return = Proj M M, start
+          |divmod = Div Is, mem_before_return, const1, const2
           |retval = Proj Is ResDiv, divmod
-          |mem_before_return = Proj M M, divmod
         """.stripMargin))
     fromMembers("public int m_div() { return 1 / 2; }") should succeedFirmConstructingWith(List(getEmptyMainMethodGraph, mDiv))
   }
@@ -131,10 +130,9 @@ class FirmConstructorTest extends FlatSpec with Matchers with BeforeAndAfter {
     val mModMethodEntity = methodEntity("__expected__4Test_m_mod", IntType, Seq())
     val mMod = FirmGraphTestHelper.buildFirmGraph(mModMethodEntity,
       intArithmeticFirm(
-        """mem = Proj M M, start
-          |divmod = Mod Is, mem, const1, const2
+        """mem_before_return = Proj M M, start
+          |divmod = Mod Is, mem_before_return, const1, const2
           |retval = Proj Is ResMod, divmod
-          |mem_before_return = Proj M M, divmod
         """.stripMargin))
     fromMembers("public int m_mod() { return 1 % 2; }") should succeedFirmConstructingWith(List(getEmptyMainMethodGraph, mMod))
   }


### PR DESCRIPTION
Memory outputs of Div/Mod are only relevant for division by zero, whose
result is undefined anyway. As memory edges introduce "false"
dependencies into the graph, eliminating them improves the visiting
order, potentially generating less spills.