### PR TITLE
Add NodeWalker for walking nodes without storing them.

### DIFF
--- a/src/main/scala/mjis/Optimizer.scala
+++ b/src/main/scala/mjis/Optimizer.scala
@@ -18,13 +18,14 @@ class Optimizer(input: Unit, config: Config) extends Phase[Unit] {
 
   def removeCriticalEdges(g: Graph): Unit = {
     val cfGraph = g.getBlockGraph.transposed
-    for (block <- NodeCollector.fromBlockWalk(g.walkBlocks))
+    g.walkBlocksWith { block =>
       if (block.getPreds.count(!_.isInstanceOf[Bad]) > 1)
         for ((pred, idx) <- block.getPreds.zipWithIndex if !pred.isInstanceOf[Bad])
           if (cfGraph.edges(pred.block).size > 1) {
             val newBlock = g.newBlock(Array(pred))
             block.setPred(idx, g.newJmp(newBlock))
           }
+    }
   }
 
   var highLevelOptimizations = List(LoopStrengthReduction, RedundantLoadElimination)

--- a/src/main/scala/mjis/opt/Inlining.scala
+++ b/src/main/scala/mjis/opt/Inlining.scala
@@ -64,7 +64,7 @@ object Inlining extends Optimization(needsBackEdges = true) {
         else if (graph.getLastIdx <= maxNodeNum) true
         else
           // since optimizations may remove nodes, we still have to actually count them
-          NodeCollector.fromWalk(graph.walk).size < maxNodeNum
+          graph.nodeCount < maxNodeNum
     }
   }
 


### PR DESCRIPTION
This avoid allocating and discarding an ArrayBuffer of nodes every time.