### PR TITLE
Try to optimize Optimization a bit

### DIFF
--- a/src/test/scala/mjis/CompilerTestMatchers.scala
+++ b/src/test/scala/mjis/CompilerTestMatchers.scala
@@ -169,7 +169,6 @@ trait CompilerTestMatchers {
 
       val opt = new Optimizer((), Config())
       opt.generalOptimizations = opt.generalOptimizations.filter(!excludedOptimizations.contains(_))
-      opt.highLevelOptimizations = opt.highLevelOptimizations.filter(!excludedOptimizations.contains(_))
 
       opt.result
       opt.dumpResult(null)


### PR DESCRIPTION
```
  ./run.sh mj-test/run/MMul.mj --timings
Lexer/Parser: 90 ms
Namer: 24 ms
Typer: 6 ms
FirmConstructor: 85 ms
	Identities$:	3 ms	
	ConstantFolding$:	12 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	7 ms	
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	12 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	8 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	2 ms	
	ConstantFolding$:	7 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	4 ms	changed!
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	4 ms	
	RedundantLoadElimination$:	3 ms	
	PureFunctionCallElimination$:	1 ms	
	LoopInvariantCodeMotion$:	13 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	6 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	2 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	4 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	4 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	2 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	4 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	3 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	0 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	1 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	3 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	2 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	4 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	2 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	0 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	1 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	2 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	0 ms	
	RedundantLoadElimination$:	1 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	2 ms	
	ConstantFolding$:	12 ms	
	Normalization$:	1 ms	
	CommonSubexpressionElimination$:	6 ms	changed!
	TrivialPhiElimination$:	2 ms	
	LoopStrengthReduction$:	7 ms	
	RedundantLoadElimination$:	3 ms	
	PureFunctionCallElimination$:	2 ms	
	LoopInvariantCodeMotion$:	7 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	4 ms	
	ConstantFolding$:	10 ms	
	Normalization$:	2 ms	
	CommonSubexpressionElimination$:	5 ms	
	TrivialPhiElimination$:	3 ms	
	LoopStrengthReduction$:	6 ms	
	RedundantLoadElimination$:	1 ms	
	PureFunctionCallElimination$:	2 ms	
	LoopInvariantCodeMotion$:	6 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	10 ms	
	Normalization$:	2 ms	
	CommonSubexpressionElimination$:	3 ms	
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	3 ms	
	RedundantLoadElimination$:	1 ms	
	PureFunctionCallElimination$:	1 ms	
	LoopInvariantCodeMotion$:	4 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	6 ms	
	Normalization$:	1 ms	
	CommonSubexpressionElimination$:	2 ms	
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	4 ms	
	RedundantLoadElimination$:	1 ms	
	PureFunctionCallElimination$:	1 ms	
	LoopInvariantCodeMotion$:	3 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	1 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	0 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	0 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	4 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	changed!
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	1 ms	
	RedundantLoadElimination$:	1 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	2 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	4 ms	
	Normalization$:	1 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	1 ms	
	LoopStrengthReduction$:	2 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	3 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	2 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	2 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	3 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	1 ms	
	ConstantFolding$:	3 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	1 ms	changed!
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	1 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	0 ms	
	ConstantFolding$:	2 ms	
	Normalization$:	0 ms	
	CommonSubexpressionElimination$:	0 ms	
	TrivialPhiElimination$:	0 ms	
	LoopStrengthReduction$:	1 ms	
	RedundantLoadElimination$:	0 ms	
	PureFunctionCallElimination$:	0 ms	
	LoopInvariantCodeMotion$:	0 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	5 ms	
	ConstantFolding$:	18 ms	changed!
	Normalization$:	4 ms	
	CommonSubexpressionElimination$:	9 ms	changed!
	TrivialPhiElimination$:	4 ms	
	LoopStrengthReduction$:	13 ms	
	RedundantLoadElimination$:	18 ms	changed!
	PureFunctionCallElimination$:	3 ms	changed!
	LoopInvariantCodeMotion$:	19 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	4 ms	changed!
	ConstantFolding$:	12 ms	changed!
	Normalization$:	4 ms	
	CommonSubexpressionElimination$:	4 ms	changed!
	TrivialPhiElimination$:	3 ms	
	LoopStrengthReduction$:	12 ms	
	RedundantLoadElimination$:	5 ms	
	PureFunctionCallElimination$:	3 ms	
	LoopInvariantCodeMotion$:	11 ms	changed!
	ConditionalMoves$:	1 ms	
	Identities$:	4 ms	
	ConstantFolding$:	12 ms	
	Normalization$:	4 ms	
	CommonSubexpressionElimination$:	4 ms	
	TrivialPhiElimination$:	3 ms	
	LoopStrengthReduction$:	12 ms	
	RedundantLoadElimination$:	4 ms	
	PureFunctionCallElimination$:	3 ms	
	LoopInvariantCodeMotion$:	8 ms	changed!
	ConditionalMoves$:	0 ms	
	Identities$:	4 ms	
	ConstantFolding$:	10 ms	
	Normalization$:	4 ms	
	CommonSubexpressionElimination$:	4 ms	
	TrivialPhiElimination$:	6 ms	
	LoopStrengthReduction$:	15 ms	
	RedundantLoadElimination$:	4 ms	
	PureFunctionCallElimination$:	3 ms	
	LoopInvariantCodeMotion$:	9 ms	
	ConditionalMoves$:	0 ms	
	Identities$:	11 ms	
	ConstantFolding$:	31 ms	
	Normalization$:	8 ms	
	CommonSubexpressionElimination$:	11 ms	changed!
	TrivialPhiElimination$:	9 ms	
	LoopStrengthReduction$:	45 ms	
	RedundantLoadElimination$:	20 ms	changed!
	PureFunctionCallElimination$:	10 ms	
	LoopInvariantCodeMotion$:	40 ms	
	ConditionalMoves$:	5 ms	
	ConditionalConstants$:	26 ms	changed!
	Identities$:	14 ms	
	ConstantFolding$:	34 ms	changed!
	Normalization$:	11 ms	
	CommonSubexpressionElimination$:	13 ms	
	TrivialPhiElimination$:	10 ms	
	LoopStrengthReduction$:	27 ms	
	RedundantLoadElimination$:	17 ms	
	PureFunctionCallElimination$:	9 ms	
	LoopInvariantCodeMotion$:	24 ms	
	ConditionalMoves$:	1 ms	
	ConditionalConstants$:	16 ms	
	Identities$:	12 ms	
	ConstantFolding$:	31 ms	
	Normalization$:	9 ms	
	CommonSubexpressionElimination$:	13 ms	
	TrivialPhiElimination$:	10 ms	
	LoopStrengthReduction$:	25 ms	
	RedundantLoadElimination$:	19 ms	
	PureFunctionCallElimination$:	9 ms	
	LoopInvariantCodeMotion$:	21 ms	
	ConditionalMoves$:	1 ms	
	ConditionalConstants$:	18 ms	
Optimizer: 1542 ms
CodeGenerator: 270 ms
RegisterAllocator: 379 ms
BlockOrdering: 44 ms
PeepholeOptimizer: 7 ms
MjisAssemblerFileGenerator: 50 ms
GccRunner: 17 ms
```