### PR TITLE
Add option to optimize all graphs (not just reachable) for testing.

### DIFF
--- a/src/main/scala/mjis/Config.scala
+++ b/src/main/scala/mjis/Config.scala
@@ -9,6 +9,7 @@ case class Config(stopAfter: String = "",
                   printTimings: Boolean = false,
                   verbose: Boolean = false,
                   inlining: Boolean = true,
+                  optimizeUnreachableGraphs: Boolean = false,
                   outFile: Path = Paths.get("a.out").toAbsolutePath) {
   def asmOutFile: Path = Paths.get(outFile.toString + ".s")
 }

--- a/src/main/scala/mjis/Optimizer.scala
+++ b/src/main/scala/mjis/Optimizer.scala
@@ -35,7 +35,9 @@ class Optimizer(input: Unit, config: Config = Config()) extends Phase[Unit] {
     (if (!config.useFirmBackend) Seq(ConditionalMoves) else Seq())
 
   def exec(optimizations: Seq[Optimization]): Unit = {
-    for (g <- CallGraph.graphsInTopologicalOrder())
+    val graphs: Iterator[Graph] = if (config.optimizeUnreachableGraphs) Program.getGraphs.iterator()
+      else CallGraph.graphsInTopologicalOrder()
+    for (g <- graphs)
       while (optimizations.map(opt => {
         val time = System.nanoTime()
         val changed = opt.optimize(g)

--- a/src/test/scala/mjis/CodeGeneratorTest.scala
+++ b/src/test/scala/mjis/CodeGeneratorTest.scala
@@ -312,21 +312,18 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
          |	movl $0, %esi
          |	call calloc
          |	movq %rax, %REG0{8}
-         |	movq %REG0{8}, %rdi
          |	call _4Test_foo
          |	movb %al, %REG1{1}
          |.L1:
          |	ret
          |
          |_4Test_foo:
-         |	movq %rdi, %REG2{8}
          |.L2:
          |.L3:
-         |	movq %REG2{8}, %rdi
          |	call _4Test_foo
-         |	movb %al, %REG3{1}
+         |	movb %al, %REG2{1}
          |.L4:
-         |	cmpb $0, %REG3{1}
+         |	cmpb $0, %REG2{1}
          |	jne .L6
          |.L5:
          |	jmp .L7
@@ -341,7 +338,7 @@ class CodeGeneratorTest extends FlatSpec with Matchers with BeforeAndAfter {
          |.L10:
          |	movb $255, %al
          |.L11:
-         |  ret""", mainMethod=false), excludedOptimizations = Set(UnusedParameterElimination, PureFunctionCallElimination))
+         |  ret""", mainMethod=false), excludedOptimizations = Set(PureFunctionCallElimination))
 
   }
 

--- a/src/test/scala/mjis/CompilerTestMatchers.scala
+++ b/src/test/scala/mjis/CompilerTestMatchers.scala
@@ -167,7 +167,7 @@ trait CompilerTestMatchers {
     override def apply(code: String): MatchResult = {
       assertExec[FirmConstructor](code)
 
-      val opt = new Optimizer((), Config())
+      val opt = new Optimizer((), Config(optimizeUnreachableGraphs = true))
       opt.generalOptimizations = opt.generalOptimizations.filter(!excludedOptimizations.contains(_))
 
       opt.result


### PR DESCRIPTION
Fixes the CodeGenerator tests. The recursive inlining test is adapted to
the fact that we can't exclude UnusedParameterElimination any more.